### PR TITLE
Flagella expression refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 vivarium processes.
 
 ## setup
-Make a python environment and install dependencies. 
+Make a python environment with Python 3 (pyenv is recommended) and install dependencies. 
 
 First install numpy:
 ```

--- a/chemotaxis/composites/chemotaxis_flagella.py
+++ b/chemotaxis/composites/chemotaxis_flagella.py
@@ -378,7 +378,6 @@ def test_ode_expression_chemotaxis(
 def test_expression_chemotaxis(
         n_flagella=5,
         total_time=10,
-        out_dir='out'
 ):
     # make the compartment
     config = get_baseline_config(n_flagella)
@@ -473,7 +472,7 @@ if __name__ == '__main__':
             out_dir=expression_out_dir)
         print_growth(timeseries)
         # plot
-        plot_timeseries(timeseries, out_dir)
+        plot_timeseries(timeseries, expression_out_dir)
         plot_config = {
             'ports': {
                 'transcripts': 'transcripts',
@@ -482,4 +481,4 @@ if __name__ == '__main__':
         plot_gene_expression_output(
             timeseries,
             plot_config,
-            out_dir)
+            expression_out_dir)

--- a/chemotaxis/composites/chemotaxis_flagella.py
+++ b/chemotaxis/composites/chemotaxis_flagella.py
@@ -11,7 +11,6 @@ import argparse
 from vivarium.library.units import units
 from vivarium.core.process import Generator
 from vivarium.core.composition import (
-    plot_compartment_topology,
     simulate_compartment_in_experiment,
     plot_simulation_output,
 )
@@ -356,9 +355,6 @@ def test_ode_expression_chemotaxis(
     config = get_baseline_config(n_flagella)
     compartment = ChemotaxisODEExpressionFlagella(config)
 
-    # save the topology network
-    plot_compartment_topology(compartment, {}, out_dir)
-
     # run experiment
     initial_state = {}
     timeline = get_brownian_ligand_timeline(total_time=total_time)
@@ -387,9 +383,6 @@ def test_expression_chemotaxis(
     config = get_baseline_config(n_flagella)
     compartment = ChemotaxisExpressionFlagella(config)
 
-    # save the topology network
-    plot_compartment_topology(compartment, {}, out_dir)
-
     # run experiment
     initial_state = get_flagella_initial_state({
         'molecules': 'internal'})
@@ -414,9 +407,6 @@ def test_variable_chemotaxis(
     # make the compartment
     config = get_baseline_config(n_flagella)
     compartment = ChemotaxisVariableFlagella(config)
-
-    # save the topology network
-    plot_compartment_topology(compartment, {}, out_dir)
 
     # run experiment
     initial_state = {}

--- a/chemotaxis/composites/chemotaxis_flagella.py
+++ b/chemotaxis/composites/chemotaxis_flagella.py
@@ -204,11 +204,12 @@ class ChemotaxisExpressionFlagella(Generator):
     n_flagella = 5
     initial_mass = 1339.0 * units.fg
     growth_rate = 0.000275
+    flagella_expression_config = get_flagella_expression_config({})
     defaults = {
-        'transcription': get_flagella_expression_config({})['transcription'],
-        'translation': get_flagella_expression_config({})['translation'],
-        'degradation': get_flagella_expression_config({})['degradation'],
-        'complexation': get_flagella_expression_config({})['complexation'],
+        'transcription': flagella_expression_config['transcription'],
+        'translation': flagella_expression_config['translation'],
+        'degradation': flagella_expression_config['degradation'],
+        'complexation': flagella_expression_config['complexation'],
         'receptor': {
             'ligand_id': ligand_id,
             'initial_ligand': initial_ligand

--- a/chemotaxis/composites/chemotaxis_flagella.py
+++ b/chemotaxis/composites/chemotaxis_flagella.py
@@ -32,7 +32,7 @@ from cell.processes.ode_expression import ODE_expression, get_flagella_expressio
 from chemotaxis.processes.flagella_motor import FlagellaMotor
 from chemotaxis.composites.flagella_expression import (
     get_flagella_expression_config,
-    get_flagella_initial_state,
+    get_flagella_expression_initial_state,
     plot_gene_expression_output,
 )
 
@@ -385,7 +385,7 @@ def test_expression_chemotaxis(
     compartment = ChemotaxisExpressionFlagella(config)
 
     # run experiment
-    initial_state = get_flagella_initial_state({
+    initial_state = get_flagella_expression_initial_state({
         'molecules': 'internal'})
     timeline = get_brownian_ligand_timeline(total_time=total_time)
     experiment_settings = {

--- a/chemotaxis/composites/chemotaxis_master.py
+++ b/chemotaxis/composites/chemotaxis_master.py
@@ -59,6 +59,7 @@ def get_metabolism_config(time_step=1):
 
 class ChemotaxisMaster(Generator):
 
+    flagella_expression_config = get_flagella_expression_config({})
     defaults = {
         'dimensions_path': ('dimensions',),
         'fields_path': ('fields',),
@@ -67,10 +68,10 @@ class ChemotaxisMaster(Generator):
         'daughter_path': tuple(),
         'transport': glucose_lactose_transport_config(),
         'metabolism': get_metabolism_config(10),
-        'transcription': get_flagella_expression_config({})['transcription'],
-        'translation': get_flagella_expression_config({})['translation'],
-        'degradation': get_flagella_expression_config({})['degradation'],
-        'complexation': get_flagella_expression_config({})['complexation'],
+        'transcription': flagella_expression_config['transcription'],
+        'translation': flagella_expression_config['translation'],
+        'degradation': flagella_expression_config['degradation'],
+        'complexation': flagella_expression_config['complexation'],
         'receptor': {'ligand': 'MeAsp'},
         'flagella': {'n_flagella': 5},
         'PMF': {},

--- a/chemotaxis/composites/flagella_expression.py
+++ b/chemotaxis/composites/flagella_expression.py
@@ -59,6 +59,7 @@ NAME = 'flagella_gene_expression'
 
 
 
+# Proteins that are not being expressed remain constant upon division
 flagella_schema_override = {
     'transcription': {
         'proteins': {
@@ -343,6 +344,7 @@ class FlagellaExpressionMetabolism(Generator):
 def run_flagella_compartment(
         compartment,
         total_time=2500,
+        emit_step=10,
         initial_state=None,
         out_dir='out'):
 
@@ -352,7 +354,7 @@ def run_flagella_compartment(
     # run simulation
     settings = {
         'total_time': total_time,
-        'emit_step': 10,
+        'emit_step': emit_step,
         'initial_state': initial_state}
     timeseries = simulate_compartment_in_experiment(compartment, settings)
 
@@ -387,6 +389,7 @@ def run_flagella_compartment(
     # plot basic sim output
     plot_settings = {
         'max_rows': 30,
+        'remove_first_timestep': True,
         'remove_zeros': True,
         'skip_ports': ['chromosome', 'ribosomes']}
     plot_simulation_output(
@@ -493,6 +496,7 @@ if __name__ == '__main__':
             total_time=total_time,
             initial_state=initial_state,
             out_dir=mtb_out_dir)
+
     elif args.expression:
         exp_out_dir = os.path.join(out_dir, 'expression')
         if not os.path.exists(exp_out_dir):
@@ -505,9 +509,10 @@ if __name__ == '__main__':
         compartment = FlagellaGeneExpression(flagella_chromosome_config)
 
         # run sim
-        total_time = 5000  # 2500
+        total_time = 2000
         run_flagella_compartment(
             compartment=compartment,
             total_time=total_time,
+            emit_step=10,
             initial_state=initial_state,
             out_dir=exp_out_dir)

--- a/chemotaxis/composites/flagella_expression.py
+++ b/chemotaxis/composites/flagella_expression.py
@@ -491,7 +491,7 @@ if __name__ == '__main__':
             compartment=compartment,
             total_time=total_time,
             initial_state=initial_state,
-            out_dir=out_dir)
+            out_dir=mtb_out_dir)
     else:
         # get initial state
         initial_state = get_flagella_expression_initial_state()

--- a/chemotaxis/composites/flagella_expression.py
+++ b/chemotaxis/composites/flagella_expression.py
@@ -207,7 +207,7 @@ class FlagellaExpressionMetabolism(Generator):
         'transport': glucose_lactose_transport_config(),
         'metabolism': default_metabolism_config(),
         'initial_mass': 0.0 * units.fg,
-        'time_step': 10,
+        'expression_time_step': 10,
         'divide': True,
     })
 
@@ -227,10 +227,10 @@ class FlagellaExpressionMetabolism(Generator):
         complexation_config = config['complexation']
 
         # update expression timestep
-        transcription_config.update({'time_step': config['time_step']})
-        translation_config.update({'time_step': config['time_step']})
-        degradation_config.update({'time_step': config['time_step']})
-        complexation_config.update({'time_step': config['time_step']})
+        transcription_config.update({'time_step': config['expression_time_step']})
+        translation_config.update({'time_step': config['expression_time_step']})
+        degradation_config.update({'time_step': config['expression_time_step']})
+        complexation_config.update({'time_step': config['expression_time_step']})
 
         # make the expression processes
         transcription = Transcription(transcription_config)
@@ -242,14 +242,12 @@ class FlagellaExpressionMetabolism(Generator):
 
         # Transport
         transport_config = config['transport']
-        transport_config.update({'time_step': config['time_step']})
         transport = ConvenienceKinetics(transport_config)
         target_fluxes = transport.kinetic_rate_laws.reaction_ids
 
         # Metabolism
         # add target fluxes from transport
         metabolism_config = config.get('metabolism')
-        metabolism_config.update({'time_step': config['time_step']})
         metabolism_config.update({'constrained_reaction_ids': target_fluxes})
         metabolism = Metabolism(metabolism_config)
 
@@ -357,11 +355,8 @@ def run_flagella_compartment(
 
     # run simulation
     settings = {
-        # a cell cycle of 2520 sec is expected to express 8 flagella.
-        # 2 flagella expected in approximately 630 seconds.
-        'total_time': 2520,
+        'total_time': 2500,
         'emit_step': 10,
-        'verbose': True,
         'initial_state': initial_state}
     timeseries = simulate_compartment_in_experiment(compartment, settings)
 

--- a/chemotaxis/composites/flagella_expression.py
+++ b/chemotaxis/composites/flagella_expression.py
@@ -172,7 +172,7 @@ def get_flagella_metabolism_initial_state(ports={}):
 # flagella expression compartment
 def FlagellaGeneExpression(config={}):
     """
-    Make a gene expression compartment with flagella expression data
+    return a GeneExpression compartment configured with flagella expression data
     """
     chromosome_config = config.get('chromosome', {})
     compartment_config = config.get('compartment', {})
@@ -192,7 +192,7 @@ class FlagellaExpressionMetabolism(Generator):
         'dimensions_path': ('dimensions',),
         'agents_path': ('agents',),
         'daughter_path': tuple(),
-        'flagella_chromosome': {},
+        'chromosome': {},
         'transport': glucose_lactose_transport_config(),
         'metabolism': default_metabolism_config(),
         'initial_mass': 0.0 * units.fg,
@@ -205,8 +205,7 @@ class FlagellaExpressionMetabolism(Generator):
             config = {}
         # get flagella expression config and update config
         chromosome_config = config.get(
-            'flagella_chromosome',
-            self.defaults['flagella_chromosome'])
+            'chromosome', self.defaults['chromosome'])
         flagella_expression_config = get_flagella_expression_config(
             chromosome_config)
         config.update(flagella_expression_config)
@@ -493,6 +492,9 @@ if __name__ == '__main__':
         mtb_out_dir = os.path.join(out_dir, 'expression_metabolism')
         if not os.path.exists(mtb_out_dir):
             os.makedirs(mtb_out_dir)
+
+        total_time = 2500
+
         # get initial state
         initial_state = get_flagella_metabolism_initial_state()
 
@@ -500,8 +502,7 @@ if __name__ == '__main__':
         flagella_config = {'divide': False}
         compartment = FlagellaExpressionMetabolism(flagella_config)
 
-        # run sim
-        total_time = 2500
+        # run sim and plot
         run_flagella_compartment(
             compartment=compartment,
             total_time=total_time,
@@ -512,6 +513,9 @@ if __name__ == '__main__':
         exp_out_dir = os.path.join(out_dir, 'expression')
         if not os.path.exists(exp_out_dir):
             os.makedirs(exp_out_dir)
+
+        total_time = 4000
+
         # get initial state
         initial_state = get_flagella_expression_initial_state()
 
@@ -519,7 +523,9 @@ if __name__ == '__main__':
         expression_timestep = 50
         parallel = True
         flagella_config = {
-            'chromosome': {},
+            'chromosome': {
+                'tsc_affinity_scaling': 1e-2,
+            },
             'compartment': {
                 'time_step': expression_timestep,
                 'transcription': {'_parallel': parallel},
@@ -530,8 +536,7 @@ if __name__ == '__main__':
         }
         compartment = FlagellaGeneExpression(flagella_config)
 
-        # run sim
-        total_time = 4000
+        # run sim and plot
         run_flagella_compartment(
             compartment=compartment,
             total_time=total_time,

--- a/chemotaxis/composites/flagella_expression.py
+++ b/chemotaxis/composites/flagella_expression.py
@@ -147,11 +147,12 @@ def get_flagella_metabolism_initial_state(ports={}):
     flagella_data = FlagellaChromosome()
     chromosome_config = flagella_data.chromosome_config
 
-    # justification for 15 ribosomes: E. coli has ~7000-70000 ribosomes
+    # justification for number of ribosomes: E. coli has ~7000-70000 ribosomes
     # (http://book.bionumbers.org/how-many-ribosomes-are-in-a-cell/),
     # and 4 flagella would make up ~0.0002 of total mass. Which indicates
-    # 2-14 ribosomes are required if allocation is proportional to mass.
-    # there are ~2000 RNAPs in E. coli (Bremer, and Dennis 1996)
+    # ~2-14 ribosomes are required to maintain 4 flagella if allocation
+    # is proportional to mass. ~2-21 ribosomes to maintain 6 flagella,
+    # There are ~2000 RNAPs in E. coli (Bremer, and Dennis 1996)
     return {
         ports.get('transcripts', 'transcripts'): {
             gene: 0
@@ -163,8 +164,8 @@ def get_flagella_metabolism_initial_state(ports={}):
             'Fnr': 10,
             'endoRNAse': 1,
             'flagella': 4,
-            UNBOUND_RIBOSOME_KEY: 15,
-            UNBOUND_RNAP_KEY: 15,
+            UNBOUND_RIBOSOME_KEY: 20,
+            UNBOUND_RNAP_KEY: 10,
         },
     }
 

--- a/chemotaxis/composites/flagella_expression.py
+++ b/chemotaxis/composites/flagella_expression.py
@@ -471,11 +471,12 @@ if __name__ == '__main__':
         os.makedirs(out_dir)
 
     parser = argparse.ArgumentParser(description='flagella expression')
-    parser.add_argument('--metabolism', '-m', action='store_true', default=False, )
+    parser.add_argument('--metabolism', '-m', action='store_true', default=False,)
+    parser.add_argument('--expression', '-e', action='store_true', default=True, )
     args = parser.parse_args()
 
     if args.metabolism:
-        mtb_out_dir = os.path.join(out_dir, 'metabolism')
+        mtb_out_dir = os.path.join(out_dir, 'expression_metabolism')
         if not os.path.exists(mtb_out_dir):
             os.makedirs(mtb_out_dir)
         # get initial state
@@ -492,7 +493,10 @@ if __name__ == '__main__':
             total_time=total_time,
             initial_state=initial_state,
             out_dir=mtb_out_dir)
-    else:
+    elif args.expression:
+        exp_out_dir = os.path.join(out_dir, 'expression')
+        if not os.path.exists(exp_out_dir):
+            os.makedirs(exp_out_dir)
         # get initial state
         initial_state = get_flagella_expression_initial_state()
 
@@ -506,4 +510,4 @@ if __name__ == '__main__':
             compartment=compartment,
             total_time=total_time,
             initial_state=initial_state,
-            out_dir=out_dir)
+            out_dir=exp_out_dir)

--- a/chemotaxis/composites/flagella_expression.py
+++ b/chemotaxis/composites/flagella_expression.py
@@ -531,7 +531,7 @@ if __name__ == '__main__':
         compartment = FlagellaGeneExpression(flagella_config)
 
         # run sim
-        total_time = 3000
+        total_time = 4000
         run_flagella_compartment(
             compartment=compartment,
             total_time=total_time,

--- a/chemotaxis/composites/transport_metabolism.py
+++ b/chemotaxis/composites/transport_metabolism.py
@@ -75,7 +75,7 @@ def lacy_expression_config():
         ('external', 'glc__D_e'),
         ('internal', 'lcts_p')]
     regulation = {
-        'lacy_RNA': 'if (external, glc__D_e) > 0.05 and (internal, lcts_p) < 0.05'}  # inhibited in this condition
+        'lacy_RNA': 'if (external, glc__D_e) > 0.01 and (internal, lcts_p) < 0.05'}  # inhibited in this condition
     transcription_leak = {
         'rate': 5e-5,
         'magnitude': 1e-6}

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -50,15 +50,15 @@ class FlagellaChromosome(object):
             ('flgBp', 'fliA'): 8e-06 * units.mM,
             ('flhBp', 'fliA'): 9e-06 * units.mM,
             ('fliAp1', 'fliA'): 5e-06 * units.mM,  # fliA self-activation takes over regulation
-            ('flgEp', 'fliA'): 1e-05 * units.mM,
+            ('flgEp', 'fliA'): 7e-06 * units.mM,
             ('fliDp', 'fliA'): 1.5e-05 * units.mM,
             ('flgKp', 'fliA'): 2e-05 * units.mM,
 
             # activation by fliA alone
-            ('fliCp', 'fliA'): 2.5e-05 * units.mM,
-            ('tarp', 'fliA'): 3e-05 * units.mM,
-            ('motAp', 'fliA'): 4e-05 * units.mM,
-            ('flgMp', 'fliA'): 4.5e-05 * units.mM,
+            ('fliCp', 'fliA'): 2.4e-05 * units.mM,
+            ('tarp', 'fliA'): 2.8e-05 * units.mM,
+            ('motAp', 'fliA'): 3.6e-05 * units.mM,
+            ('flgMp', 'fliA'): 4.1e-05 * units.mM,
         }
 
         self.factor_thresholds.update(parameters.get('thresholds', {}))

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -27,61 +27,38 @@ class FlagellaChromosome(object):
             self.ecoli_sequence = read_sequence(ECOLI_GENOME_PATH)
 
         self.factor_thresholds = {
-            # flhD
+            # flhDC activation by CRP
             ('flhDp', 'CRP'): 1e-05 * units.mM,
 
-            # fliL
+            # activation by flhDC
             ('fliLp1', 'flhDC'): 6e-06 * units.mM,
-            ('fliLp1', 'fliA'): 1.3e-05 * units.mM,
-
-            # fliE
             ('fliEp1', 'flhDC'): 9e-06 * units.mM,
-            ('fliEp1', 'fliA'): 1.1e-05 * units.mM,
-
-            # fliF
             ('fliFp1', 'flhDC'): 1.2e-05 * units.mM,
-            ('fliFp1', 'fliA'): 1e-05 * units.mM,
-
-            # flgA
             ('flgAp', 'flhDC'): 1.4e-05 * units.mM,
-            ('flgAp', 'fliA'): 8e-06 * units.mM,
-
-            # flgB
             ('flgBp', 'flhDC'): 1.6e-05 * units.mM,
-            ('flgBp', 'fliA'): 9e-07 * units.mM,
+            ('flhBp', 'flhDC'): 1.8e-05 * units.mM,
+            ('fliAp1', 'flhDC'): 2.1e-05 * units.mM,  # activating fliA begins hand-off of regulation
+            ('flgEp', 'flhDC'): 2.2e-05 * units.mM,
+            ('fliDp', 'flhDC'): 2.4e-05 * units.mM,
+            ('flgKp', 'flhDC'): 2.6e-05 * units.mM,
 
-            # flhB
-            ('flhBp', 'flhDC'): 1.7e-05 * units.mM,
-            ('flhBp', 'fliA'): 1e-06 * units.mM,
+            # activation by fliA (also flhDC)
+            ('fliLp1', 'fliA'): 4e-06 * units.mM,
+            ('fliEp1', 'fliA'): 5e-06 * units.mM,
+            ('fliFp1', 'fliA'): 6e-06 * units.mM,
+            ('flgAp', 'fliA'): 7e-06 * units.mM,
+            ('flgBp', 'fliA'): 8e-06 * units.mM,
+            ('flhBp', 'fliA'): 9e-06 * units.mM,
+            ('fliAp1', 'fliA'): 4e-06 * units.mM,  # fliA self-activation takes over regulation
+            ('flgEp', 'fliA'): 1e-05 * units.mM,
+            ('fliDp', 'fliA'): 1.5e-05 * units.mM,
+            ('flgKp', 'fliA'): 2e-05 * units.mM,
 
-            # fliA
-            # self-activation determines hand-off of regulation from flhDC
-            ('fliAp1', 'flhDC'): 1.9e-05 * units.mM,
-            ('fliAp1', 'fliA'): 4e-06 * units.mM,
-
-            # flgE
-            ('flgEp', 'flhDC'): 2.1e-05 * units.mM,
-            ('flgEp', 'fliA'): 3e-06 * units.mM,
-
-            # fliD
-            ('fliDp', 'flhDC'): 2.3e-05 * units.mM,
-            ('fliDp', 'fliA'): 4e-06 * units.mM,
-
-            # flgK
-            ('flgKp', 'flhDC'): 2.5e-05 * units.mM,
-            ('flgKp', 'fliA'): 5e-06 * units.mM,
-
-            # fliC
-            ('fliCp', 'fliA'): 7e-06 * units.mM,
-
-            # tarp
-            ('tarp', 'fliA'): 9e-06 * units.mM,
-
-            # motA
-            ('motAp', 'fliA'): 1.1e-05 * units.mM,
-
-            # flgM
-            ('flgMp', 'fliA'): 1.3e-05 * units.mM,
+            # activation by fliA alone
+            ('fliCp', 'fliA'): 2.5e-05 * units.mM,
+            ('tarp', 'fliA'): 3e-05 * units.mM,
+            ('motAp', 'fliA'): 4e-05 * units.mM,
+            ('flgMp', 'fliA'): 4.5e-05 * units.mM,
         }
 
         self.factor_thresholds.update(parameters.get('thresholds', {}))
@@ -373,7 +350,7 @@ class FlagellaChromosome(object):
             for key, sequence in self.protein_sequences.items()}
 
         # transcript affinities are the affinities with which a ribosome binds to a transcript
-        # tr_affinity_scaling scales affinities relative to the requirements for a single flagellum.
+        # tr_affinity_scaling scales affinities linearly relative to the requirements of a flagellum.
         min_tr_affinity = parameters.get('min_tr_affinity', 1e-3)
         scaling_rate = 0  # parameters.get('tr_affinity_rate', 1e-5)
         tr_affinity_scaling = {

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -31,34 +31,34 @@ class FlagellaChromosome(object):
             ('flhDp', 'CRP'): 1e-05 * units.mM,
 
             # activation by flhDC
-            ('fliLp1', 'flhDC'): 6e-06 * units.mM,
-            ('fliEp1', 'flhDC'): 9e-06 * units.mM,
-            ('fliFp1', 'flhDC'): 1.2e-05 * units.mM,
-            ('flgAp', 'flhDC'): 1.4e-05 * units.mM,
-            ('flgBp', 'flhDC'): 1.8e-05 * units.mM,
-            ('flhBp', 'flhDC'): 2.1e-05 * units.mM,
-            ('fliAp1', 'flhDC'): 2.6e-05 * units.mM,  # activating fliA begins hand-off of regulation
-            ('flgEp', 'flhDC'): 2.8e-05 * units.mM,
-            ('fliDp', 'flhDC'): 3.0e-05 * units.mM,
-            ('flgKp', 'flhDC'): 3.2e-05 * units.mM,
+            ('fliLp1', 'flhDC'): 4e-05 * units.mM,
+            ('fliEp1', 'flhDC'): 5e-05 * units.mM,
+            ('fliFp1', 'flhDC'): 6e-05 * units.mM,
+            ('flgAp', 'flhDC'): 7e-05 * units.mM,
+            ('flgBp', 'flhDC'): 8e-05 * units.mM,
+            ('flhBp', 'flhDC'): 9e-05 * units.mM,
+            ('fliAp1', 'flhDC'): 1e-04 * units.mM,  # activating fliA begins hand-off of regulation
+            ('flgEp', 'flhDC'): 1.2e-04 * units.mM,
+            ('fliDp', 'flhDC'): 1.3e-04 * units.mM,
+            ('flgKp', 'flhDC'): 1.4e-04 * units.mM,
 
-            # activation by fliA (also flhDC)
-            ('fliLp1', 'fliA'): 4e-06 * units.mM,
-            ('fliEp1', 'fliA'): 5e-06 * units.mM,
-            ('fliFp1', 'fliA'): 6e-06 * units.mM,
-            ('flgAp', 'fliA'): 7e-06 * units.mM,
-            ('flgBp', 'fliA'): 8e-06 * units.mM,
-            ('flhBp', 'fliA'): 9e-06 * units.mM,
-            ('fliAp1', 'fliA'): 5e-06 * units.mM,  # fliA self-activation takes over regulation
-            ('flgEp', 'fliA'): 7e-06 * units.mM,
-            ('fliDp', 'fliA'): 1.5e-05 * units.mM,
-            ('flgKp', 'fliA'): 2e-05 * units.mM,
+            # activation by fliA
+            ('fliLp1', 'fliA'): 1.0e-05 * units.mM,
+            ('fliEp1', 'fliA'): 1.4e-05 * units.mM,
+            ('fliFp1', 'fliA'): 1.8e-05 * units.mM,
+            ('flgAp', 'fliA'): 2.2e-05 * units.mM,
+            ('flgBp', 'fliA'): 2.6e-05 * units.mM,
+            ('flhBp', 'fliA'): 3.0e-05 * units.mM,
+            ('fliAp1', 'fliA'): 3.6e-05 * units.mM,  # fliA self-activation takes over regulation
+            ('flgEp', 'fliA'): 3.8e-05 * units.mM,
+            ('fliDp', 'fliA'): 4.2e-05 * units.mM,
+            ('flgKp', 'fliA'): 4.3e-05 * units.mM,
 
             # activation by fliA alone
-            ('fliCp', 'fliA'): 2.4e-05 * units.mM,
-            ('tarp', 'fliA'): 2.8e-05 * units.mM,
-            ('motAp', 'fliA'): 3.6e-05 * units.mM,
-            ('flgMp', 'fliA'): 4.1e-05 * units.mM,
+            ('fliCp', 'fliA'): 4.2e-05 * units.mM,
+            ('tarp', 'fliA'): 4.4e-05 * units.mM,
+            ('motAp', 'fliA'): 4.6e-05 * units.mM,
+            ('flgMp', 'fliA'): 4.8e-05 * units.mM,
         }
 
         self.factor_thresholds.update(parameters.get('thresholds', {}))
@@ -71,10 +71,10 @@ class FlagellaChromosome(object):
                 'fliE': ['fliE'],
                 'fliF': ['fliF', 'fliG', 'fliH', 'fliI', 'fliJ', 'fliK'],
                 'flgA': ['flgA', 'flgM', 'flgN'],
-                'flgE': ['flgE'],
                 'flgB': ['flgB', 'flgC', 'flgD', 'flgE', 'flgF', 'flgG', 'flgH', 'flgI', 'flgJ'],
                 'flhB': ['flhB', 'flhA', 'flhE'],
                 'fliA': ['fliA', 'fliZ'], # ignore 'tcyJ' for now
+                'flgE': ['flgE'],
                 'fliD': ['fliD', 'fliS', 'fliT'],
                 'flgK': ['flgK', 'flgL'],
                 'fliC': ['fliC'],
@@ -317,7 +317,7 @@ class FlagellaChromosome(object):
 
         # promoter affinities are binding affinity of RNAP onto promoter
         self.promoter_affinities = {
-            ('flhDp', 'CRP'): 0.01}
+            ('flhDp', 'CRP'): 0.1}
         # self.promoter_affinities[('motAp', 'CpxR')] = 1.0
         flhDC_affinities = binary_sum_gates(activation_coefficients)
         self.promoter_affinities.update(flhDC_affinities)
@@ -357,6 +357,7 @@ class FlagellaChromosome(object):
             'flhB': 1e-3,
             'fliI': 2e-3,
             'fliH': 3e-3,
+            'fliA': 1e-3,
         }
         self.transcript_affinities = {}
         for (operon, product) in self.transcripts:

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -413,13 +413,13 @@ class FlagellaChromosome(object):
             'flhDC': {
                 'flhD': -4.0,
                 'flhC': -2.0,
-                'flhDC': 1.0
+                'flhDC': 1.0,
             },
             'flagellar motor switch reaction': {
                 'flagellar motor switch': 1.0,
                 'fliG': -26.0,
                 'fliM': -34.0,
-                'fliN': -1.0
+                'fliN': -1.0,
             },
             'flagellar export apparatus reaction 1': {
                 'flagellar export apparatus subunit': 1.0,
@@ -430,12 +430,12 @@ class FlagellaChromosome(object):
                 'fliQ': -1.0,
                 'fliR': -1.0,
                 'fliJ': -1.0,
-                'fliI': -6.0
+                'fliI': -6.0,
             },
             'flagellar export apparatus reaction 2': {
                 'flagellar export apparatus': 1.0,
                 'flagellar export apparatus subunit': -1.0,
-                'fliH': -12.0
+                'fliH': -12.0,
             },
             'flagellar motor reaction': {
                 'flagellar motor': 1.0,
@@ -450,11 +450,11 @@ class FlagellaChromosome(object):
                 'flgG': -1.0,
                 'flgI': -1.0,
                 'fliF': -1.0,
-                'fliE': -1.0
+                'fliE': -1.0,
             },
             'flagellar hook reaction': {
                 'flagellar hook': 1,
-                'flgE': -120.0
+                'flgE': -120.0,
             },
             'flagellum reaction': {
                 'flagella': 1.0,
@@ -464,7 +464,7 @@ class FlagellaChromosome(object):
                 'flgL': -1.0,
                 'flgK': -1.0,
                 'fliD': -5.0,
-                'flagellar hook': -1
+                'flagellar hook': -1,
             }
         }
 

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -27,31 +27,61 @@ class FlagellaChromosome(object):
             self.ecoli_sequence = read_sequence(ECOLI_GENOME_PATH)
 
         self.factor_thresholds = {
+            # flhD
             ('flhDp', 'CRP'): 1e-05 * units.mM,
+
+            # fliL
             ('fliLp1', 'flhDC'): 1e-06 * units.mM,
             ('fliLp1', 'fliA'): 1.3e-05 * units.mM,
-            ('fliEp1', 'flhDC'): 4e-06 * units.mM,
+
+            # fliE
+            ('fliEp1', 'flhDC'): 5e-06 * units.mM,
             ('fliEp1', 'fliA'): 1.1e-05 * units.mM,
+
+            # fliF
             ('fliFp1', 'flhDC'): 7e-06 * units.mM,
             ('fliFp1', 'fliA'): 1e-05 * units.mM,
-            ('flgBp', 'flhDC'): 1e-05 * units.mM,
-            ('flgBp', 'fliA'): 8e-06 * units.mM,
-            ('flgAp', 'flhDC'): 1.3e-05 * units.mM,
-            ('flgAp', 'fliA'): 6e-06 * units.mM,
-            ('flhBp', 'flhDC'): 1.5e-05 * units.mM,
-            ('flhBp', 'fliA'): 5e-06 * units.mM,
-            ('fliAp1', 'flhDC'): 1.7e-05 * units.mM,
-            ('fliAp1', 'fliA'): 4e-06 * units.mM,
-            ('flgEp', 'flhDC'): 1.9e-05 * units.mM,
+
+            # flgA
+            ('flgAp', 'flhDC'): 1e-05 * units.mM,
+            ('flgAp', 'fliA'): 8e-06 * units.mM,
+
+            # flgB
+            ('flgBp', 'flhDC'): 1.3e-05 * units.mM,
+            ('flgBp', 'fliA'): 9e-07 * units.mM,
+
+            # flhB
+            ('flhBp', 'flhDC'): 1.7e-05 * units.mM,
+            ('flhBp', 'fliA'): 1e-06 * units.mM,
+
+            # fliA
+            ('fliAp1', 'flhDC'): 2.5e-05 * units.mM,
+            ('fliAp1', 'fliA'): 2e-06 * units.mM,
+
+            # flgE
+            ('flgEp', 'flhDC'): 2.9e-05 * units.mM,
             ('flgEp', 'fliA'): 3e-06 * units.mM,
-            ('fliDp', 'flhDC'): 1.9e-05 * units.mM,
-            ('fliDp', 'fliA'): 3e-06 * units.mM,
-            ('flgKp', 'flhDC'): 2.1e-05 * units.mM,
-            ('flgKp', 'fliA'): 1e-06 * units.mM,
-            ('fliCp', 'fliA'): 5e-06 * units.mM,
-            ('tarp', 'fliA'): 7e-06 * units.mM,
-            ('motAp', 'fliA'): 9e-06 * units.mM,
-            ('flgMp', 'fliA'): 1.1e-06 * units.mM}
+
+            # fliD
+            ('fliDp', 'flhDC'): 3.3e-05 * units.mM,
+            ('fliDp', 'fliA'): 4e-06 * units.mM,
+
+            # flgK
+            ('flgKp', 'flhDC'): 3.5e-05 * units.mM,  # 2.5e-05
+            ('flgKp', 'fliA'): 5e-06 * units.mM,
+
+            # fliC
+            ('fliCp', 'fliA'): 7e-06 * units.mM,
+
+            # tarp
+            ('tarp', 'fliA'): 9e-06 * units.mM,
+
+            # motA
+            ('motAp', 'fliA'): 1.1e-05 * units.mM,
+
+            # flgM
+            ('flgMp', 'fliA'): 1.3e-05 * units.mM,
+        }
 
         self.factor_thresholds.update(parameters.get('thresholds', {}))
 
@@ -63,7 +93,6 @@ class FlagellaChromosome(object):
                 'fliE': ['fliE'],
                 'fliF': ['fliF', 'fliG', 'fliH', 'fliI', 'fliJ', 'fliK'],
                 'flgA': ['flgA', 'flgM', 'flgN'],
-                'flgM': ['flgM', 'flgN'],
                 'flgE': ['flgE'],
                 'flgB': ['flgB', 'flgC', 'flgD', 'flgE', 'flgF', 'flgG', 'flgH', 'flgI', 'flgJ'],
                 'flhB': ['flhB', 'flhA', 'flhE'],
@@ -72,7 +101,9 @@ class FlagellaChromosome(object):
                 'flgK': ['flgK', 'flgL'],
                 'fliC': ['fliC'],
                 'tar': ['tar', 'tap', 'cheR', 'cheB', 'cheY', 'cheZ'],
-                'motA': ['motA', 'motB', 'cheA', 'cheW']},
+                'motA': ['motA', 'motB', 'cheA', 'cheW'],
+                'flgM': ['flgM', 'flgN'],
+            },
             'promoters': {
                 'flhDp': {
                     'id': 'flhDp',
@@ -282,12 +313,12 @@ class FlagellaChromosome(object):
                 'flhDC': 0.45, 'fliA': 0.35},
             'fliFp1': {
                 'flhDC': 0.35, 'fliA': 0.30},
-            'flgBp': {
-                'flhDC': 0.35, 'fliA': 0.45},
             'flgAp': {
                 'flhDC': 0.15, 'fliA': 0.3},
             'flgEp': {
                 'flhDC': 1.0, 'fliA': 4.0},
+            'flgBp': {
+                'flhDC': 0.35, 'fliA': 0.45},
             'flhBp': {
                 'flhDC': 0.1, 'fliA': 0.35},
             'fliAp1': {
@@ -298,6 +329,7 @@ class FlagellaChromosome(object):
                 'flhDC': 1.2, 'fliA': 0.25}
         }
 
+        # binary sums for flhDC_factors
         def binary_sum_gates(promoter_factors):
             affinities = {}
             first, second = list(promoter_factors[
@@ -347,7 +379,7 @@ class FlagellaChromosome(object):
                 [key[1]])
             for key, sequence in self.protein_sequences.items()}
 
-        # transcript affinities are the affinities transcripts to bind a ribosome and translate to protein
+        # transcript affinities are the affinities with which a ribosome binds to a transcript
         # transcript affinities are scaled relative to the requirements to build a single full flagellum.
         self.min_tr_affinity = parameters.get('min_tr_affinity', 1e-1)
         tr_affinity_scaling = {
@@ -377,11 +409,11 @@ class FlagellaChromosome(object):
         self.complexation_complex_ids = [
             'flhDC',
             'flagellar motor switch',
-            'flagella',
+            'flagellar hook',
             'flagellar export apparatus subunit',
             'flagellar export apparatus',
-            'flagellar hook',
-            'flagellar motor']
+            'flagellar motor',
+            'flagella']
 
         self.complexation_stoichiometry = {
             'flhDC': {
@@ -409,7 +441,7 @@ class FlagellaChromosome(object):
             'flagellar export apparatus reaction 2': {
                 'flagellar export apparatus': 1.0,
                 'flagellar export apparatus subunit': -1.0,
-                'fliH': -12.0,
+                'fliH': -12.0
             },
             'flagellar motor reaction': {
                 'flagellar motor': 1.0,
@@ -424,11 +456,11 @@ class FlagellaChromosome(object):
                 'flgG': -1.0,
                 'flgI': -1.0,
                 'fliF': -1.0,
-                'fliE': -1.0,
+                'fliE': -1.0
             },
             'flagellar hook reaction': {
                 'flagellar hook': 1,
-                'flgE': -120.0,
+                'flgE': -120.0
             },
             'flagellum reaction': {
                 'flagella': 1.0,
@@ -438,7 +470,7 @@ class FlagellaChromosome(object):
                 'flgL': -1.0,
                 'flgK': -1.0,
                 'fliD': -5.0,
-                'flagellar hook': -1,
+                'flagellar hook': -1
             }
         }
 

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -31,23 +31,23 @@ class FlagellaChromosome(object):
             ('flhDp', 'CRP'): 1e-05 * units.mM,
 
             # fliL
-            ('fliLp1', 'flhDC'): 1e-06 * units.mM,
+            ('fliLp1', 'flhDC'): 6e-06 * units.mM,
             ('fliLp1', 'fliA'): 1.3e-05 * units.mM,
 
             # fliE
-            ('fliEp1', 'flhDC'): 5e-06 * units.mM,
+            ('fliEp1', 'flhDC'): 9e-06 * units.mM,
             ('fliEp1', 'fliA'): 1.1e-05 * units.mM,
 
             # fliF
-            ('fliFp1', 'flhDC'): 7e-06 * units.mM,
+            ('fliFp1', 'flhDC'): 1.2e-05 * units.mM,
             ('fliFp1', 'fliA'): 1e-05 * units.mM,
 
             # flgA
-            ('flgAp', 'flhDC'): 1e-05 * units.mM,
+            ('flgAp', 'flhDC'): 1.4e-05 * units.mM,
             ('flgAp', 'fliA'): 8e-06 * units.mM,
 
             # flgB
-            ('flgBp', 'flhDC'): 1.3e-05 * units.mM,
+            ('flgBp', 'flhDC'): 1.6e-05 * units.mM,
             ('flgBp', 'fliA'): 9e-07 * units.mM,
 
             # flhB
@@ -55,19 +55,20 @@ class FlagellaChromosome(object):
             ('flhBp', 'fliA'): 1e-06 * units.mM,
 
             # fliA
-            ('fliAp1', 'flhDC'): 2.5e-05 * units.mM,
-            ('fliAp1', 'fliA'): 2e-06 * units.mM,
+            # self-activation determines hand-off of regulation from flhDC
+            ('fliAp1', 'flhDC'): 1.9e-05 * units.mM,
+            ('fliAp1', 'fliA'): 4e-06 * units.mM,
 
             # flgE
-            ('flgEp', 'flhDC'): 2.9e-05 * units.mM,
+            ('flgEp', 'flhDC'): 2.1e-05 * units.mM,
             ('flgEp', 'fliA'): 3e-06 * units.mM,
 
             # fliD
-            ('fliDp', 'flhDC'): 3.3e-05 * units.mM,
+            ('fliDp', 'flhDC'): 2.3e-05 * units.mM,
             ('fliDp', 'fliA'): 4e-06 * units.mM,
 
             # flgK
-            ('flgKp', 'flhDC'): 3.5e-05 * units.mM,  # 2.5e-05
+            ('flgKp', 'flhDC'): 2.5e-05 * units.mM,
             ('flgKp', 'fliA'): 5e-06 * units.mM,
 
             # fliC
@@ -306,30 +307,22 @@ class FlagellaChromosome(object):
         self.fliA_activated = [
             'fliCp', 'tarp', 'motAp', 'flgMp']
 
-        flhDC_factors = {
-            'fliLp1': {
-                'flhDC': 1.2, 'fliA': 0.25},
-            'fliEp1': {
-                'flhDC': 0.45, 'fliA': 0.35},
-            'fliFp1': {
-                'flhDC': 0.35, 'fliA': 0.30},
-            'flgAp': {
-                'flhDC': 0.15, 'fliA': 0.3},
-            'flgEp': {
-                'flhDC': 1.0, 'fliA': 4.0},
-            'flgBp': {
-                'flhDC': 0.35, 'fliA': 0.45},
-            'flhBp': {
-                'flhDC': 0.1, 'fliA': 0.35},
-            'fliAp1': {
-                'flhDC': 1.0, 'fliA': 0.3},
-            'fliDp': {
-                'flhDC': 1.2, 'fliA': 0.25},
-            'flgKp': {
-                'flhDC': 1.2, 'fliA': 0.25}
-        }
+        # activation coefficients from:
+        # Kalir, S., & Alon, U. (2004). "Using a quantitative blueprint to reprogram
+        # the dynamics of the flagella gene network." Cell.
+        activation_coefficients = {
+            'fliLp1': {'flhDC': 1.2,  'fliA': 0.25},
+            'fliEp1': {'flhDC': 0.45, 'fliA': 0.35},
+            'fliFp1': {'flhDC': 0.35, 'fliA': 0.30},
+            'flgAp':  {'flhDC': 0.15, 'fliA': 0.3},
+            'flgEp':  {'flhDC': 1.0,  'fliA': 4.0},
+            'flgBp':  {'flhDC': 0.35, 'fliA': 0.45},
+            'flhBp':  {'flhDC': 0.1,  'fliA': 0.35},
+            'fliAp1': {'flhDC': 1.0,  'fliA': 0.3},
+            'fliDp':  {'flhDC': 1.2,  'fliA': 0.25},
+            'flgKp':  {'flhDC': 1.2,  'fliA': 0.25}}
 
-        # binary sums for flhDC_factors
+        # binary sums for activation_coefficients based on TF concentrations
         def binary_sum_gates(promoter_factors):
             affinities = {}
             first, second = list(promoter_factors[
@@ -349,7 +342,7 @@ class FlagellaChromosome(object):
         self.promoter_affinities = {
             ('flhDp', 'CRP'): 0.01}
         # self.promoter_affinities[('motAp', 'CpxR')] = 1.0
-        flhDC_affinities = binary_sum_gates(flhDC_factors)
+        flhDC_affinities = binary_sum_gates(activation_coefficients)
         self.promoter_affinities.update(flhDC_affinities)
         # for promoter in self.flhDC_activated:
         #     self.promoter_affinities[(promoter, 'flhDC')] = 1.0
@@ -380,8 +373,9 @@ class FlagellaChromosome(object):
             for key, sequence in self.protein_sequences.items()}
 
         # transcript affinities are the affinities with which a ribosome binds to a transcript
-        # transcript affinities are scaled relative to the requirements to build a single full flagellum.
-        self.min_tr_affinity = parameters.get('min_tr_affinity', 1e-1)
+        # tr_affinity_scaling scales affinities relative to the requirements for a single flagellum.
+        min_tr_affinity = parameters.get('min_tr_affinity', 1e-3)
+        scaling_rate = 0  # parameters.get('tr_affinity_rate', 1e-5)
         tr_affinity_scaling = {
             'fliL': 2,
             'fliM': 34,
@@ -392,10 +386,10 @@ class FlagellaChromosome(object):
             'flgE': 120}
         self.transcript_affinities = {}
         for (operon, product) in self.transcripts:
-            self.transcript_affinities[(operon, product)] = self.min_tr_affinity * tr_affinity_scaling.get(product,1)
+            self.transcript_affinities[(operon, product)] = \
+                min_tr_affinity + scaling_rate * tr_affinity_scaling.get(product, 0)
         self.transcript_affinities.update(
             parameters.get('transcript_affinities', {}))
-
 
         self.transcription_factors = [
             'flhDC', 'fliA', 'CsgD', 'CRP', 'GadE', 'H-NS', 'CpxR', 'Fnr']

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -35,12 +35,12 @@ class FlagellaChromosome(object):
             ('fliEp1', 'flhDC'): 9e-06 * units.mM,
             ('fliFp1', 'flhDC'): 1.2e-05 * units.mM,
             ('flgAp', 'flhDC'): 1.4e-05 * units.mM,
-            ('flgBp', 'flhDC'): 1.6e-05 * units.mM,
-            ('flhBp', 'flhDC'): 1.8e-05 * units.mM,
-            ('fliAp1', 'flhDC'): 2.1e-05 * units.mM,  # activating fliA begins hand-off of regulation
-            ('flgEp', 'flhDC'): 2.2e-05 * units.mM,
-            ('fliDp', 'flhDC'): 2.4e-05 * units.mM,
-            ('flgKp', 'flhDC'): 2.6e-05 * units.mM,
+            ('flgBp', 'flhDC'): 1.8e-05 * units.mM,
+            ('flhBp', 'flhDC'): 2.1e-05 * units.mM,
+            ('fliAp1', 'flhDC'): 2.6e-05 * units.mM,  # activating fliA begins hand-off of regulation
+            ('flgEp', 'flhDC'): 2.8e-05 * units.mM,
+            ('fliDp', 'flhDC'): 3.0e-05 * units.mM,
+            ('flgKp', 'flhDC'): 3.2e-05 * units.mM,
 
             # activation by fliA (also flhDC)
             ('fliLp1', 'fliA'): 4e-06 * units.mM,
@@ -49,7 +49,7 @@ class FlagellaChromosome(object):
             ('flgAp', 'fliA'): 7e-06 * units.mM,
             ('flgBp', 'fliA'): 8e-06 * units.mM,
             ('flhBp', 'fliA'): 9e-06 * units.mM,
-            ('fliAp1', 'fliA'): 4e-06 * units.mM,  # fliA self-activation takes over regulation
+            ('fliAp1', 'fliA'): 5e-06 * units.mM,  # fliA self-activation takes over regulation
             ('flgEp', 'fliA'): 1e-05 * units.mM,
             ('fliDp', 'fliA'): 1.5e-05 * units.mM,
             ('flgKp', 'fliA'): 2e-05 * units.mM,
@@ -325,8 +325,6 @@ class FlagellaChromosome(object):
         #     self.promoter_affinities[(promoter, 'flhDC')] = 1.0
         for promoter in self.fliA_activated:
             self.promoter_affinities[(promoter, 'fliA')] = 1.0
-        self.promoter_affinities.update(
-            parameters.get('promoter_affinities', {}))
         promoter_affinity_scaling = parameters.get('promoter_affinity_scaling', 1)
         self.promoter_affinities = {
             promoter: affinity * promoter_affinity_scaling
@@ -350,23 +348,20 @@ class FlagellaChromosome(object):
             for key, sequence in self.protein_sequences.items()}
 
         # transcript affinities are the affinities with which a ribosome binds to a transcript
-        # tr_affinity_scaling scales affinities linearly relative to the requirements of a flagellum.
-        min_tr_affinity = parameters.get('min_tr_affinity', 1e-3)
-        scaling_rate = 0  # parameters.get('tr_affinity_rate', 1e-5)
-        tr_affinity_scaling = {
-            'fliL': 2,
-            'fliM': 34,
-            'fliG': 26,
-            'fliH': 12,
-            'fliI': 6,
-            'fliD': 5,
-            'flgE': 120}
+        # tsc_affinity_scaling scales affinities to meet the requirements of a flagellum.
+        affinity_scaling = parameters.get('tsc_affinity_scaling', 1)
+        min_affinity = 1e-2
+        added_affinity = {
+            'fliG': 3e-2,
+            'flgE': 2e-3,
+            'flhB': 1e-3,
+            'fliI': 2e-3,
+            'fliH': 3e-3,
+        }
         self.transcript_affinities = {}
         for (operon, product) in self.transcripts:
             self.transcript_affinities[(operon, product)] = \
-                min_tr_affinity + scaling_rate * tr_affinity_scaling.get(product, 0)
-        self.transcript_affinities.update(
-            parameters.get('transcript_affinities', {}))
+                affinity_scaling * (min_affinity + added_affinity.get(product, 0))
 
         self.transcription_factors = [
             'flhDC', 'fliA', 'CsgD', 'CRP', 'GadE', 'H-NS', 'CpxR', 'Fnr']

--- a/chemotaxis/data/chromosomes/flagella_chromosome.py
+++ b/chemotaxis/data/chromosomes/flagella_chromosome.py
@@ -30,7 +30,7 @@ class FlagellaChromosome(object):
             # flhDC activation by CRP
             ('flhDp', 'CRP'): 1e-05 * units.mM,
 
-            # activation by flhDC
+            # activation by flhDC (increasing threshold)
             ('fliLp1', 'flhDC'): 4e-05 * units.mM,
             ('fliEp1', 'flhDC'): 5e-05 * units.mM,
             ('fliFp1', 'flhDC'): 6e-05 * units.mM,
@@ -38,27 +38,27 @@ class FlagellaChromosome(object):
             ('flgBp', 'flhDC'): 8e-05 * units.mM,
             ('flhBp', 'flhDC'): 9e-05 * units.mM,
             ('fliAp1', 'flhDC'): 1e-04 * units.mM,  # activating fliA begins hand-off of regulation
-            ('flgEp', 'flhDC'): 1.2e-04 * units.mM,
-            ('fliDp', 'flhDC'): 1.3e-04 * units.mM,
-            ('flgKp', 'flhDC'): 1.4e-04 * units.mM,
+            ('flgEp', 'flhDC'): 1.1e-04 * units.mM,
+            ('fliDp', 'flhDC'): 1.2e-04 * units.mM,
+            ('flgKp', 'flhDC'): 1.3e-04 * units.mM,
 
-            # activation by fliA
-            ('fliLp1', 'fliA'): 1.0e-05 * units.mM,
-            ('fliEp1', 'fliA'): 1.4e-05 * units.mM,
-            ('fliFp1', 'fliA'): 1.8e-05 * units.mM,
-            ('flgAp', 'fliA'): 2.2e-05 * units.mM,
-            ('flgBp', 'fliA'): 2.6e-05 * units.mM,
-            ('flhBp', 'fliA'): 3.0e-05 * units.mM,
-            ('fliAp1', 'fliA'): 3.6e-05 * units.mM,  # fliA self-activation takes over regulation
-            ('flgEp', 'fliA'): 3.8e-05 * units.mM,
-            ('fliDp', 'fliA'): 4.2e-05 * units.mM,
-            ('flgKp', 'fliA'): 4.3e-05 * units.mM,
+            # activation by fliA (decreasing threshold)
+            ('fliLp1', 'fliA'): 4.2e-05 * units.mM,
+            ('fliEp1', 'fliA'): 4.1e-05 * units.mM,
+            ('fliFp1', 'fliA'): 4.0e-05 * units.mM,
+            ('flgAp', 'fliA'): 3.9e-05 * units.mM,
+            ('flgBp', 'fliA'): 3.8e-05 * units.mM,
+            ('flhBp', 'fliA'): 3.7e-05 * units.mM,
+            ('fliAp1', 'fliA'): 3.5e-05 * units.mM,  # fliA self-activation takes over regulation
+            ('flgEp', 'fliA'): 3.4e-05 * units.mM,
+            ('fliDp', 'fliA'): 3.3e-05 * units.mM,
+            ('flgKp', 'fliA'): 3.2e-05 * units.mM,
 
-            # activation by fliA alone
-            ('fliCp', 'fliA'): 4.2e-05 * units.mM,
+            # activation by fliA alone (increasing threshold)
+            ('fliCp', 'fliA'): 4.3e-05 * units.mM,
             ('tarp', 'fliA'): 4.4e-05 * units.mM,
-            ('motAp', 'fliA'): 4.6e-05 * units.mM,
-            ('flgMp', 'fliA'): 4.8e-05 * units.mM,
+            ('motAp', 'fliA'): 4.5e-05 * units.mM,
+            ('flgMp', 'fliA'): 4.6e-05 * units.mM,
         }
 
         self.factor_thresholds.update(parameters.get('thresholds', {}))
@@ -317,7 +317,7 @@ class FlagellaChromosome(object):
 
         # promoter affinities are binding affinity of RNAP onto promoter
         self.promoter_affinities = {
-            ('flhDp', 'CRP'): 0.1}
+            ('flhDp', 'CRP'): 0.15}
         # self.promoter_affinities[('motAp', 'CpxR')] = 1.0
         flhDC_affinities = binary_sum_gates(activation_coefficients)
         self.promoter_affinities.update(flhDC_affinities)
@@ -352,12 +352,23 @@ class FlagellaChromosome(object):
         affinity_scaling = parameters.get('tsc_affinity_scaling', 1)
         min_affinity = 1e-2
         added_affinity = {
-            'fliG': 3e-2,
-            'flgE': 2e-3,
-            'flhB': 1e-3,
-            'fliI': 2e-3,
-            'fliH': 3e-3,
-            'fliA': 1e-3,
+            'fliG': 3e0 * min_affinity,
+            'flgE': 2e-1 * min_affinity,
+            'flhB': 1e-1 * min_affinity,
+            'fliI': 3e-1 * min_affinity,
+            'fliH': 3e-1 * min_affinity,
+            'fliA': 4e-1 * min_affinity,
+            # reduce affinity
+            'tar': -5e-1 * min_affinity,
+            'tap': -5e-1 * min_affinity,
+            'motA': -5e-1 * min_affinity,
+            'motB': -5e-1 * min_affinity,
+            'cheZ': -5e-1 * min_affinity,
+            'cheY': -5e-1 * min_affinity,
+            'cheW': -5e-1 * min_affinity,
+            'cheR': -5e-1 * min_affinity,
+            'cheB': -5e-1 * min_affinity,
+            'cheA': -5e-1 * min_affinity,
         }
         self.transcript_affinities = {}
         for (operon, product) in self.transcripts:

--- a/chemotaxis/experiments/control.py
+++ b/chemotaxis/experiments/control.py
@@ -9,6 +9,9 @@ Handles experiment specifications for `paper_experiments.py`
 import os
 import argparse
 
+# vivarium-core imports
+from vivarium.library.units import units
+
 # directories
 from cell.plots.multibody_physics import plot_tags, plot_snapshots
 from vivarium.core.composition import (
@@ -19,6 +22,35 @@ from vivarium.core.composition import (
 from chemotaxis import EXPERIMENT_OUT_DIR
 
 
+
+def single_agent_config(config):
+    width = 1
+    length = 2
+    # volume = volume_from_length(length, width)
+    bounds = config.get('bounds')
+    location = config.get('location')
+    location = [loc * bounds[n] for n, loc in enumerate(location)]
+
+    return {
+        'boundary': {
+            'location': location,
+            # 'angle': np.random.uniform(0, 2 * PI),
+            # 'volume': volume,
+            'length': length,
+            'width': width,
+            'mass': 1339 * units.fg,
+            # 'thrust': 0,
+            # 'torque': 0,
+        }
+    }
+
+def agent_body_config(config):
+    agent_ids = config['agent_ids']
+    agent_config = {
+        agent_id: single_agent_config(config)
+        for agent_id in agent_ids}
+    return {
+        'agents': agent_config}
 
 
 def plot_control(data, config, out_dir='out'):

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -418,14 +418,17 @@ def flagella_expression_network(out_dir='out'):
 
 # figure 6b
 def flagella_just_in_time(out_dir='out'):
-    total_time = 3000
+    total_time = 4000
 
     # make the compartment
-    # longer time steps for transport/metabolism speed up the simulation,
-    # and still provide the required nutrients
+    # longer time steps speed up the simulation,
+    # and are sufficient to provide the required nutrients
     compartment_config = {
+        'expression_time_step': 60,
         'transport': {'time_step': 60},
         'metabolism': {'time_step': 60},
+        'chromosome': {'tsc_affinity_scaling': 1e-1},
+        'divide': False,
     }
     compartment = FlagellaExpressionMetabolism(compartment_config)
 
@@ -439,8 +442,15 @@ def flagella_just_in_time(out_dir='out'):
     }
     timeseries = simulate_compartment_in_experiment(compartment, settings)
 
-    # plot output as heat maps
+    # plot "just-in-time" output as a heat maps
+    # transcript_list is made in expected just-in-time order
+    # order proteins and small molecules alphabetically
     flagella_data = FlagellaChromosome()
+    transcript_list = list(flagella_data.chromosome_config['genes'].keys())
+    protein_list = flagella_data.complexation_monomer_ids + flagella_data.complexation_complex_ids
+    protein_list.sort()
+    molecule_list = list(nucleotides.values()) + list(amino_acids.values())
+    molecule_list.sort()
     plot_config = {
         'name': 'flagella',
         'ports': {
@@ -449,9 +459,9 @@ def flagella_just_in_time(out_dir='out'):
             'molecules': 'molecules',
         },
         'plot_ports': {
-            'transcripts': list(flagella_data.chromosome_config['genes'].keys()),
-            'proteins': flagella_data.complexation_monomer_ids + flagella_data.complexation_complex_ids,
-            'molecules': list(nucleotides.values()) + list(amino_acids.values()),
+            'transcripts': transcript_list,
+            'proteins': protein_list,
+            'molecules': molecule_list,
         }
     }
     plot_timeseries_heatmaps(timeseries, plot_config, out_dir)

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -421,6 +421,8 @@ def flagella_just_in_time(out_dir='out'):
     total_time = 2500
 
     # make the compartment
+    # longer time steps for transport/metabolism speed up the simulation,
+    # and still provide the required nutrients
     compartment_config = {
         'transport': {'time_step': 60},
         'metabolism': {'time_step': 60},
@@ -433,7 +435,6 @@ def flagella_just_in_time(out_dir='out'):
     # run simulation with helper function simulate_compartment_in_experiment
     settings = {
         'total_time': total_time,
-        'emit_step': 4000.0,
         'initial_state': initial_state,
     }
     timeseries = simulate_compartment_in_experiment(compartment, settings)

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -408,9 +408,13 @@ def flagella_expression_network(out_dir='out'):
 
 # figure 6b
 def flagella_just_in_time(out_dir='out'):
+    total_time = 2500
 
     # make the compartment
-    compartment_config = {}
+    compartment_config = {
+        'transport': {'time_step': 60},
+        'metabolism': {'time_step': 60},
+    }
     compartment = FlagellaExpressionMetabolism(compartment_config)
 
     # get the initial state
@@ -418,11 +422,9 @@ def flagella_just_in_time(out_dir='out'):
 
     # run simulation
     settings = {
-        # a cell cycle of 2520 sec is expected to express 8 flagella.
-        # 2 flagella expected in approximately 630 seconds.
-        'total_time': 500,
+        # a cell cycle of 2500 sec is expected to express 4 flagella.
+        'total_time': total_time,
         'emit_step': 10.0,
-        'verbose': True,
         'initial_state': initial_state,
     }
     timeseries = simulate_compartment_in_experiment(compartment, settings)
@@ -443,6 +445,7 @@ def flagella_just_in_time(out_dir='out'):
         }
     }
     plot_timeseries_heatmaps(timeseries, plot_config, out_dir)
+    plot_simulation_output(timeseries, {}, out_dir)
 
 
 # figure 6c

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -424,12 +424,12 @@ def flagella_just_in_time(out_dir='out'):
     settings = {
         # a cell cycle of 2500 sec is expected to express 4 flagella.
         'total_time': total_time,
-        'emit_step': 10.0,
+        'emit_step': 60.0,
         'initial_state': initial_state,
     }
     timeseries = simulate_compartment_in_experiment(compartment, settings)
 
-    # plot output
+    # plot timeseries heatmaps
     flagella_data = FlagellaChromosome()
     plot_config = {
         'name': 'flagella',
@@ -445,7 +445,13 @@ def flagella_just_in_time(out_dir='out'):
         }
     }
     plot_timeseries_heatmaps(timeseries, plot_config, out_dir)
-    plot_simulation_output(timeseries, {}, out_dir)
+
+    # plot sim output
+    sim_plot_config = {
+        'max_rows': 30,
+        'remove_zeros': True,
+        'skip_ports': ['chromosome', 'ribosomes']}
+    plot_simulation_output(timeseries, sim_plot_config, out_dir)
 
 
 # figure 6c

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -480,7 +480,7 @@ def run_heterogeneous_flagella_experiment(out_dir='out'):
         'ids': ['flagella_metabolism'],
         'type': FlagellaExpressionMetabolism,
         'config': {
-            'time_step': process_time_step,
+            'expression_time_step': process_time_step,
             'agents_path': ('..', '..', 'agents'),
             'fields_path': ('..', '..', 'fields'),
             'dimensions_path': ('..', '..', 'dimensions'),

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -418,7 +418,7 @@ def flagella_expression_network(out_dir='out'):
 
 # figure 6b
 def flagella_just_in_time(out_dir='out'):
-    total_time = 2500
+    total_time = 3000
 
     # make the compartment
     # longer time steps for transport/metabolism speed up the simulation,
@@ -467,7 +467,7 @@ def flagella_just_in_time(out_dir='out'):
 # figure 6c
 def run_heterogeneous_flagella_experiment(out_dir='out'):
 
-    total_time = 15000
+    total_time = 18000
     emit_step = 120
     process_time_step = 60
     bounds = [17, 17]
@@ -536,7 +536,7 @@ def run_heterogeneous_flagella_experiment(out_dir='out'):
 
 
 # figure 7a
-def variable_flagella(out_dir='out'):
+def run_flagella_activity(out_dir='out'):
     total_time = 80
     time_step = 0.01
     initial_flagella = 1
@@ -771,7 +771,7 @@ experiments_library = {
     '6a': flagella_expression_network,
     '6b': flagella_just_in_time,
     '6c': run_heterogeneous_flagella_experiment,
-    '7a': variable_flagella,
+    '7a': run_flagella_activity,
     '7b': run_chemoreceptor_pulse,
     '7c': run_chemotaxis_transduction,
     '7d': run_chemotaxis_experiment,

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -107,7 +107,7 @@ def growth_division_experiment(out_dir='out'):
     fields = ['glc__D_e', 'lcts_e']
     emit_fields = ['glc__D_e']
     initial_agent_id = 'growth_division'
-    parallel = False
+    parallel = True
 
     # configure the agents and environment
     agents_config = {
@@ -208,10 +208,8 @@ def transport_metabolism(out_dir='out'):
         'transport': {'time_step': 10},
         'expression': {
             'time_step': 1,
-            # increased leak rate makes more frequent bursts
-            'transcription_leak': {
-                'rate': 5e-3,
-            },
+            # increased leak rate makes more frequent bursts for improved visualization
+            'transcription_leak': {'rate': 5e-3},
         },
         'divide': False,
     }
@@ -223,8 +221,8 @@ def transport_metabolism(out_dir='out'):
         override=initial_concentrations)
 
     # run simulation with helper function simulate_compartment_in_experiment
+    # configure non-spatial environment process with environment_volume
     sim_settings = {
-        # configure non-spatial environment
         'environment': {
             'volume': environment_volume,
             'concentrations': external_state,
@@ -479,7 +477,7 @@ def flagella_just_in_time(out_dir='out'):
 # figure 6c
 def run_heterogeneous_flagella_experiment(out_dir='out'):
 
-    total_time = 15000  # 15000
+    total_time = 16000
     emit_step = 120
     process_time_step = 60
     environment_time_step = 120
@@ -541,6 +539,12 @@ def run_heterogeneous_flagella_experiment(out_dir='out'):
     experiment.update(total_time)
     data = experiment.emitter.get_data()
     experiment.end()  # end required for parallel processes
+
+    # remove the first timestep so that it is not always the brightest
+    # all subsequent snapshots are of larger cells, and so their concentration
+    # of flagella looks like less
+    if 0.0 in data:
+        del data[0.0]
 
     # plot output
     plot_config = {

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -291,6 +291,7 @@ def transport_metabolism_environment(out_dir='out'):
             time_step=10,
             bounds=bounds,
             n_bins=[40, 40],
+            jitter_force=5e-3,
             depth=50.0,
             diffusion=1e-3,
             concentrations=media,

--- a/chemotaxis/experiments/paper_experiments.py
+++ b/chemotaxis/experiments/paper_experiments.py
@@ -292,7 +292,7 @@ def transport_metabolism_environment(out_dir='out'):
             bounds=bounds,
             n_bins=[40, 40],
             depth=50.0,
-            diffusion=1e-4,
+            diffusion=1e-3,
             concentrations=media,
             keep_fields_emit=emit_fields,
         )
@@ -307,6 +307,7 @@ def transport_metabolism_environment(out_dir='out'):
                        'of LacY',
         'total_time': total_time,
         'emit_step': emit_step,
+        'emitter': {'type': 'database'},
     }
     experiment = agent_environment_experiment(
         agents_config=agents_config,


### PR DESCRIPTION
This PR is part clean up and part re-parameterization. 

- The clean up focuses on the composites and their associated functions (initial states, tests, configuration functions, plotting) -- ```chemotaxis_flagella.py```, ```chemotaxis_master.py```, ```flagella_expression.py```, and ```transport_metabolism.py```. 

- Flagella expression is re-parameterized to have a longer just-in-time output, and the expression of only 4 flagella per cell cycle. This includes changes to ```flagella_chromosome``` and the configuration settings in ```flagella_expression.py```. Notably initial ribosome counts are down to 15, based on the mass-proportionate allocation assumption described in the comments. Glucose/Lactose transport kinetics are also refined to better match available data.

Here is the new just-in-time figure of flagella transcript expression:
![flagella_transcripts](https://user-images.githubusercontent.com/6809431/93425992-05780a00-f870-11ea-8108-5ae0534137b7.png)

